### PR TITLE
Filter log based on module and/or level.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ x86 = "0.21"
 log = "0.4"
 termcodes = "0.0.1"
 spin = "0.5.2"
+heapless = "0.5.1"
 
 [features]
 use_ioports = [] # Always use ioports, even when compiling for a UNIX architecture (used by kvmtests)


### PR DESCRIPTION
running 15 tests
test test::filter_beginning_longest_match ... ok
test test::filter_info ... ok
test test::match_beginning ... ok
test test::match_beginning_longest_match ... ok
test test::match_full_path ... ok
test test::no_match ... ok
test test::match_default ... ok
test test::parse_args_valid ... ok
test test::parse_default ... ok
test test::parse_spec_empty_level ... ok
test test::parse_spec_invalid_crate ... ok
test test::parse_spec_global ... ok
test test::parse_spec_invalid_level ... ok
test test::parse_spec_string_level ... ok
test test::zero_level ... ok