### PR TITLE
Preparations for aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "klogger"
-version = "0.0.14"
+version = "0.0.15"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>", "Ankit Bhardwaj <ankitb@cs.utah.edu>", "Reto Achermann <achreto@gmail.com>"]
 
 description = "Library for logging in kernel mode."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,29 @@
 [package]
 name = "klogger"
 version = "0.0.14"
-authors = ["Gerd Zellweger <mail@gerdzellweger.com>", "Ankit Bhardwaj <ankitb@cs.utah.edu>"]
+authors = ["Gerd Zellweger <mail@gerdzellweger.com>", "Ankit Bhardwaj <ankitb@cs.utah.edu>", "Reto Achermann <achreto@gmail.com>"]
 
 description = "Library for logging in kernel mode."
 repository = "https://github.com/gz/rust-klogger"
 
 readme = "README.md"
-keywords = ["serial", "os", "amd64", "x86"]
+keywords = ["serial", "os", "amd64", "x86", "armv8"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-x86 = { version = "0.51", features = ["unstable"] }
 log = "0.4"
 termcodes = "0.0.1"
 spin = "0.5.2"
 heapless = "0.7.14"
+
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+x86 = { version = "0.51", features = ["unstable"] }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+armv8 = { git = "https://github.com/achreto/rust-armv8" }
+
+
 
 [features]
 use_ioports = [] # Always use ioports, even when compiling for a UNIX architecture (used by kvmtests)

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -15,11 +15,11 @@ pub fn get_timestamp() -> u64 {
 }
 
 pub fn has_tsc() -> bool {
-    false;
+    false
 }
 
 pub fn has_invariant_tsc() -> bool {
-    false;
+    false
 }
 
 pub fn get_tsc_frequency_hz() -> Option<u64> {

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -1,5 +1,3 @@
-use crate::{KHZ_TO_HZ, MHZ_TO_HZ};
-
 /// Write a string to the output channel.
 pub unsafe fn puts(s: &str) {}
 

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -1,26 +1,25 @@
+use crate::{KHZ_TO_HZ, MHZ_TO_HZ};
+
 /// Write a string to the output channel.
-pub unsafe fn puts(s: &str) {
-    print!("{}", s);
-}
+pub unsafe fn puts(s: &str) {}
 
-pub unsafe fn putc(c: char) {
-    print!("{}", c);
-}
+pub unsafe fn putc(c: char) {}
 
-pub fn set_output(_fd: u16) {
-    // not doing anything
-}
+/// Write a single byte to the output channel.
+unsafe fn putb(port: u16, b: u8) {}
+
+pub fn set_output(port: u16) {}
 
 pub fn get_timestamp() -> u64 {
     0
 }
 
 pub fn has_tsc() -> bool {
-    false
+    false;
 }
 
 pub fn has_invariant_tsc() -> bool {
-    false
+    false;
 }
 
 pub fn get_tsc_frequency_hz() -> Option<u64> {

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -1,7 +1,18 @@
 use core::sync::atomic::AtomicU16;
 use core::sync::atomic::Ordering;
 
+extern crate x86;
+
 use x86::io;
+
+/// One Mhz is that many Hz.
+const MHZ_TO_HZ: u64 = 1000 * 1000;
+
+/// One Khz is that many Hz.
+const KHZ_TO_HZ: u64 = 1000;
+
+/// One sec has that many ns.
+const _NS_PER_SEC: u64 = 1_000_000_000u64;
 
 pub static SERIAL_PRINT_PORT: AtomicU16 = AtomicU16::new(0x3f8); /* default COM1 */
 
@@ -27,4 +38,51 @@ unsafe fn putb(port: u16, b: u8) {
 
 pub fn set_output(port: u16) {
     SERIAL_PRINT_PORT.store(port, Ordering::Relaxed);
+}
+
+pub fn get_timestamp() -> u64 {
+    unsafe { x86::time::rdtsc() }
+}
+
+pub fn has_tsc() -> bool {
+    let cpuid = x86::cpuid::CpuId::new();
+    cpuid
+        .get_feature_info()
+        .map_or(false, |finfo| finfo.has_tsc())
+}
+
+pub fn has_invariant_tsc() -> bool {
+    let cpuid = x86::cpuid::CpuId::new();
+    cpuid
+        .get_advanced_power_mgmt_info()
+        .map_or(false, |efinfo| efinfo.has_invariant_tsc())
+}
+
+pub fn get_tsc_frequency_hz() -> Option<u64> {
+    let cpuid = x86::cpuid::CpuId::new();
+    cpuid.get_tsc_info().and_then(|tinfo| {
+        if tinfo.nominal_frequency() != 0 {
+            // If we have a crystal clock we can calculate the tsc frequency directly
+            tinfo.tsc_frequency()
+        } else if tinfo.numerator() != 0 && tinfo.denominator() != 0 {
+            // Skylake and Kabylake don't report the crystal clock frequency,
+            // so we approximate with CPU base frequency:
+            cpuid.get_processor_frequency_info().map(|pinfo| {
+                let cpu_base_freq_hz = pinfo.processor_base_frequency() as u64 * MHZ_TO_HZ;
+                let crystal_hz =
+                    cpu_base_freq_hz * tinfo.denominator() as u64 / tinfo.numerator() as u64;
+                crystal_hz * tinfo.numerator() as u64 / tinfo.denominator() as u64
+            })
+        } else {
+            // We couldn't figure out the TSC frequency
+            None
+        }
+    })
+}
+
+pub fn get_vmm_tsc_frequency_hz() -> Option<u64> {
+    let cpuid = x86::cpuid::CpuId::new();
+    cpuid
+        .get_hypervisor_info()
+        .and_then(|hv| hv.tsc_frequency().map(|tsc_khz| tsc_khz as u64 * KHZ_TO_HZ))
 }

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::Ordering;
 
 extern crate x86;
 
-use x86::io;
+use self::x86::io;
 
 /// One Mhz is that many Hz.
 const MHZ_TO_HZ: u64 = 1000 * 1000;


### PR DESCRIPTION
This PR brings in some initial re-structuring to support aarch64. What's missing for aarch64 is the support of a serial driver (e.g., pl011) and the timer access through the armv8 crate. 